### PR TITLE
Fix for Shelter Person Roles

### DIFF
--- a/src/main/java/org/mindera/fur/code/aspect/roleauth/RequiresRole.java
+++ b/src/main/java/org/mindera/fur/code/aspect/roleauth/RequiresRole.java
@@ -1,0 +1,16 @@
+package org.mindera.fur.code.aspect.roleauth;
+
+import org.mindera.fur.code.model.Role;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequiresRole {
+    Role value();
+    String shelterIdField() default "";
+    int shelterIdParam() default -1;
+}

--- a/src/main/java/org/mindera/fur/code/aspect/roleauth/RequiresRole.java
+++ b/src/main/java/org/mindera/fur/code/aspect/roleauth/RequiresRole.java
@@ -13,4 +13,6 @@ public @interface RequiresRole {
     Role value();
     String shelterIdField() default "";
     int shelterIdParam() default -1;
+    boolean isPetOperation() default false;
+    int petIdParam() default -1;
 }

--- a/src/main/java/org/mindera/fur/code/aspect/roleauth/RoleAuthAspect.java
+++ b/src/main/java/org/mindera/fur/code/aspect/roleauth/RoleAuthAspect.java
@@ -1,0 +1,135 @@
+package org.mindera.fur.code.aspect.roleauth;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.mindera.fur.code.exceptions.person.PersonException;
+import org.mindera.fur.code.infra.security.TokenService;
+import org.mindera.fur.code.model.Person;
+import org.mindera.fur.code.model.ShelterPersonRoles;
+import org.mindera.fur.code.repository.PersonRepository;
+import org.mindera.fur.code.repository.ShelterPersonRolesRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Parameter;
+
+@Aspect
+@Component
+public class RoleAuthAspect {
+
+    private final TokenService tokenService;
+    private final PersonRepository personRepository;
+    private final ShelterPersonRolesRepository shelterPersonRolesRepository;
+
+    public RoleAuthAspect(TokenService tokenService,
+                          PersonRepository personRepository,
+                          ShelterPersonRolesRepository shelterPersonRolesRepository) {
+        this.tokenService = tokenService;
+        this.personRepository = personRepository;
+        this.shelterPersonRolesRepository = shelterPersonRolesRepository;
+    }
+
+    /**
+     * Authorize role.
+     *
+     * @param joinPoint The join point.
+     * @param requiresRole The requires role.
+     * @return The object.
+     * @throws Throwable The throwable.
+     */
+    @Around("@annotation(requiresRole)")
+    public Object authorizeRole(ProceedingJoinPoint joinPoint, RequiresRole requiresRole) throws Throwable {
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes == null) {
+            throw new IllegalStateException("Request attributes not found");
+        }
+
+        String authHeader = attributes.getRequest().getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new PersonException("UNAUTHORIZED");
+        }
+
+        String jwtToken = authHeader.substring(7);
+        String email = tokenService.validateToken(jwtToken);
+
+        Person person = personRepository.findByEmail(email);
+        if (person == null) {
+            throw new PersonException("PERSON_NOT_FOUND");
+        }
+
+        Long shelterId = extractShelterId(joinPoint, requiresRole);
+
+        ShelterPersonRoles personRole = shelterPersonRolesRepository
+                .findByPersonIdAndShelterId(person.getId(), shelterId)
+                .orElseThrow(() -> new PersonException("PERSON_NOT_ASSOCIATED_WITH_SHELTER"));
+
+        if (personRole.getRole().ordinal() > requiresRole.value().ordinal()) {
+            throw new PersonException("INSUFFICIENT_PERMISSIONS");
+        }
+
+        return joinPoint.proceed();
+    }
+
+    /**
+     * Extract shelter id.
+     *
+     * @param joinPoint The join point.
+     * @param requiresRole The requires role.
+     * @return The shelter id.
+     */
+    private Long extractShelterId(ProceedingJoinPoint joinPoint, RequiresRole requiresRole) {
+        if (!requiresRole.shelterIdField().isEmpty()) {
+            // Extract from request body
+            Object requestBody = findRequestBody(joinPoint.getArgs());
+            if (requestBody == null) {
+                throw new IllegalArgumentException("Request body not found");
+            }
+            return extractShelterIdFromField(requestBody, requiresRole.shelterIdField());
+        } else if (requiresRole.shelterIdParam() >= 0) {
+            // Extract from method parameter
+            Object[] args = joinPoint.getArgs();
+            if (requiresRole.shelterIdParam() >= args.length) {
+                throw new IllegalArgumentException("Invalid shelter ID parameter index");
+            }
+            return (Long) args[requiresRole.shelterIdParam()];
+        } else {
+            throw new IllegalArgumentException("No shelter ID source specified");
+        }
+    }
+
+    /**
+     * Find request body.
+     *
+     * @param args The args.
+     * @return The request body.
+     */
+    private Object findRequestBody(Object[] args) {
+        for (Object arg : args) {
+            if (arg != null && !(arg instanceof String)) {
+                return arg;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Extract shelter id from field.
+     *
+     * @param requestBody The request body.
+     * @param fieldName The field name.
+     * @return The shelter id.
+     */
+    private Long extractShelterIdFromField(Object requestBody, String fieldName) {
+        try {
+            Field field = requestBody.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return (Long) field.get(requestBody);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new IllegalArgumentException("Unable to extract shelterId from request body", e);
+        }
+    }
+}

--- a/src/main/java/org/mindera/fur/code/controller/PersonController.java
+++ b/src/main/java/org/mindera/fur/code/controller/PersonController.java
@@ -3,6 +3,7 @@ package org.mindera.fur.code.controller;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.Data;
+import org.mindera.fur.code.aspect.roleauth.RequiresRole;
 import org.mindera.fur.code.dto.donation.DonationCreateDTO;
 import org.mindera.fur.code.dto.donation.DonationDTO;
 import org.mindera.fur.code.dto.person.PersonCreationDTO;
@@ -11,7 +12,10 @@ import org.mindera.fur.code.dto.pet.PetCreateDTO;
 import org.mindera.fur.code.dto.pet.PetDTO;
 import org.mindera.fur.code.dto.shelter.ShelterCreationDTO;
 import org.mindera.fur.code.dto.shelterPersonRoles.ShelterPersonRolesDTO;
+import org.mindera.fur.code.infra.security.TokenService;
 import org.mindera.fur.code.model.Role;
+import org.mindera.fur.code.repository.PersonRepository;
+import org.mindera.fur.code.repository.ShelterPersonRolesRepository;
 import org.mindera.fur.code.service.PersonService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -71,14 +75,14 @@ public class PersonController {
      * @return The shelter person roles DTO.
      */
 
+    @RequiresRole(value = Role.ADMIN, shelterIdParam = 1)
     @PostMapping("/add-person-to-shelter")
     @Schema(description = "Add a person to a shelter")
-    public ResponseEntity<ShelterPersonRolesDTO> addPersonToShelter(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader,
-                                                                    @RequestBody AddPersonToShelterRequest request) {
+    public ResponseEntity<ShelterPersonRolesDTO> addPersonToShelter(@RequestBody AddPersonToShelterRequest request) {
         return new ResponseEntity<>(personService.addPersonToShelter(
-                authorizationHeader,
                 request.getPersonId(),
-                request.getShelterId()),
+                request.getShelterId()
+                ),
                 HttpStatus.OK);
     }
 
@@ -102,12 +106,11 @@ public class PersonController {
      * @param petCreationDTO The pet creation DTO.
      * @return The pet DTO.
      */
-
+    @RequiresRole(value = Role.ADMIN, shelterIdField = "shelterId")
     @PostMapping("/create-pet")
     @Schema(description = "Create a pet")
-    public ResponseEntity<PetDTO> createPet(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader,
-                                            @RequestBody PetCreateDTO petCreationDTO) {
-        return new ResponseEntity<>(personService.createPet(authorizationHeader,petCreationDTO), HttpStatus.CREATED);
+    public ResponseEntity<PetDTO> createPet(@RequestBody PetCreateDTO petCreationDTO) {
+        return new ResponseEntity<>(personService.createPet(petCreationDTO), HttpStatus.CREATED);
     }
 
     /**
@@ -152,7 +155,7 @@ public class PersonController {
      * @return The list of person DTOs.
      */
 
-
+    @RequiresRole(value = Role.ADMIN, shelterIdParam = 0)
     @GetMapping("/get-all-persons-in-shelter/{id}")
     @Schema(description = "Get all persons in a shelter")
     public ResponseEntity<List<PersonDTO>> getAllPersonsInShelter(@PathVariable Long id) {
@@ -179,6 +182,7 @@ public class PersonController {
      * @param role The role of the person.
      * @return The person DTO.
      */
+
     @PatchMapping("/set-person-role/{id}")
     @Schema(description = "Set the role of a person")
     public ResponseEntity<PersonDTO> setPersonRole(@PathVariable Long id, @RequestBody Role role) {

--- a/src/main/java/org/mindera/fur/code/controller/PersonController.java
+++ b/src/main/java/org/mindera/fur/code/controller/PersonController.java
@@ -14,6 +14,7 @@ import org.mindera.fur.code.dto.shelterPersonRoles.ShelterPersonRolesDTO;
 import org.mindera.fur.code.model.Role;
 import org.mindera.fur.code.service.PersonService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -72,8 +73,13 @@ public class PersonController {
 
     @PostMapping("/add-person-to-shelter")
     @Schema(description = "Add a person to a shelter")
-    public ResponseEntity<ShelterPersonRolesDTO> addPersonToShelter(@RequestBody AddPersonToShelterRequest request) {
-        return new ResponseEntity<>(personService.addPersonToShelter(request.getPersonId(), request.getShelterId()), HttpStatus.OK);
+    public ResponseEntity<ShelterPersonRolesDTO> addPersonToShelter(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader,
+                                                                    @RequestBody AddPersonToShelterRequest request) {
+        return new ResponseEntity<>(personService.addPersonToShelter(
+                authorizationHeader,
+                request.getPersonId(),
+                request.getShelterId()),
+                HttpStatus.OK);
     }
 
     /**
@@ -99,8 +105,9 @@ public class PersonController {
 
     @PostMapping("/create-pet")
     @Schema(description = "Create a pet")
-    public ResponseEntity<PetDTO> createPet(@RequestBody PetCreateDTO petCreationDTO) {
-        return new ResponseEntity<>(personService.createPet(petCreationDTO), HttpStatus.CREATED);
+    public ResponseEntity<PetDTO> createPet(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader,
+                                            @RequestBody PetCreateDTO petCreationDTO) {
+        return new ResponseEntity<>(personService.createPet(authorizationHeader,petCreationDTO), HttpStatus.CREATED);
     }
 
     /**

--- a/src/main/java/org/mindera/fur/code/repository/ShelterPersonRolesRepository.java
+++ b/src/main/java/org/mindera/fur/code/repository/ShelterPersonRolesRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 
 /**
@@ -21,4 +22,6 @@ public interface ShelterPersonRolesRepository extends JpaRepository<ShelterPerso
     @Schema(description = "Find person by shelter id")
     @Query("SELECT spr.person FROM ShelterPersonRoles spr WHERE spr.shelter.id = :shelterId")
     List<Person> findPersonsByShelterId(@Param("shelterId") Long shelterId);
+
+    Optional<ShelterPersonRoles> findByPersonIdAndShelterId(Long personId, Long shelterId);
 }

--- a/src/main/java/org/mindera/fur/code/service/FileService.java
+++ b/src/main/java/org/mindera/fur/code/service/FileService.java
@@ -5,8 +5,10 @@ import io.minio.errors.*;
 import io.minio.messages.Item;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.apache.commons.lang3.StringUtils;
+import org.mindera.fur.code.aspect.roleauth.RequiresRole;
 import org.mindera.fur.code.dto.file.FileUploadDTO;
 import org.mindera.fur.code.exceptions.file.FileException;
+import org.mindera.fur.code.model.Role;
 import org.mindera.fur.code.service.pet.PetService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
@@ -46,6 +48,7 @@ public class FileService {
      * @param id       the ID of the pet associated with the file.
      * @param file     the file to upload.
      */
+    @RequiresRole(value = Role.ADMIN, isPetOperation = true, petIdParam = 2)
     public void uploadImagePet(String filePath, FileUploadDTO file, Long id) {
         if (id == null) {
             throw new IllegalArgumentException("Pet ID must be provided");
@@ -385,6 +388,7 @@ public class FileService {
         return imageList;
     }
 
+    @RequiresRole(value = Role.ADMIN, isPetOperation = true, petIdParam = 1)
     public void deleteImagePet(String filePath, Long petId) {
         try {
             // Logic to delete the file from the storage (e.g., Minio, S3)

--- a/src/main/java/org/mindera/fur/code/service/PersonService.java
+++ b/src/main/java/org/mindera/fur/code/service/PersonService.java
@@ -255,33 +255,13 @@ public class PersonService {
      */
 
     @Transactional
-    public ShelterPersonRolesDTO addPersonToShelter(String authorizationHeader, Long personId, Long shelterId) {
+    public ShelterPersonRolesDTO addPersonToShelter(Long personId, Long shelterId) {
         Person person = personRepository.findById(personId).orElseThrow(
                 () -> new PersonException(PersonMessages.PERSON_NOT_FOUND)
         );
         Shelter shelter = shelterRepository.findById(shelterId).orElseThrow(
                 () -> new PersonException(PersonMessages.SHELTER_NOT_FOUND)
         );
-
-        String jwtToken = extractJwtFromAuthorizationHeader(authorizationHeader);
-        String email = tokenService.validateToken(jwtToken);
-
-        Person personAuthorized = personRepository.findByEmail(email);
-        if (personAuthorized == null) {
-            throw new PersonException(PersonMessages.PERSON_NOT_FOUND);
-        }
-
-        ShelterPersonRoles personAuthorizedRole = shelterPersonRolesRepository
-                .findByPersonIdAndShelterId(personAuthorized.getId(), shelterId)
-                .orElseThrow(() -> new PersonException("PERSON_NOT_ASSOCIATED_WITH_SHELTER"));
-
-//        MASTER: 0
-//        ADMIN: 1
-//        MANAGER: 2
-//        USER: 3
-        if (personAuthorizedRole.getRole().ordinal() > Role.ADMIN.ordinal()) {
-            throw new PersonException("INSUFFICIENT_PERMISSIONS_TO_ADD_PERSON_TO_SHELTER");
-        }
 
         ShelterPersonRoles shelterPersonRoles = new ShelterPersonRoles();
         shelterPersonRoles.setPerson(person);
@@ -452,8 +432,8 @@ public class PersonService {
         personRepository.save(person);
         ShelterDTO shelter = shelterService.createShelter(shelterCreationDTO);
         Long shelterId = shelter.getId();
-        String test = "";
-        return addPersonToShelter(test, id, shelterId);
+
+        return addPersonToShelter(id, shelterId);
     }
 
     /**
@@ -465,31 +445,9 @@ public class PersonService {
 
     @Transactional
     @Schema(description = "Create a pet")
-    public PetDTO createPet(String authorizationHeader, PetCreateDTO petCreationDTO) {
-        Long shelterId = petCreationDTO.getShelterId();
-        String jwtToken = extractJwtFromAuthorizationHeader(authorizationHeader);
-        String email = tokenService.validateToken(jwtToken);
-
-        Person personAuthorized = personRepository.findByEmail(email);
-        if (personAuthorized == null) {
-            throw new PersonException(PersonMessages.PERSON_NOT_FOUND);
-        }
-
-        ShelterPersonRoles personAuthorizedRole = shelterPersonRolesRepository
-                .findByPersonIdAndShelterId(personAuthorized.getId(), shelterId)
-                .orElseThrow(() -> new PersonException("PERSON_NOT_ASSOCIATED_WITH_SHELTER"));
-
-//        MASTER: 0
-//        ADMIN: 1
-//        MANAGER: 2
-//        USER: 3
-        if (personAuthorizedRole.getRole().ordinal() > Role.MANAGER.ordinal()) {
-            throw new PersonException("INSUFFICIENT_PERMISSIONS_TO_CREATE_PET");
-        }
-
+    public PetDTO createPet(PetCreateDTO petCreationDTO) {
         return petService.addPet(petCreationDTO);
     }
-
 
     /**
      * Sets the role of a person based on the provided PersonDTO.


### PR DESCRIPTION
Roles are now shelter-specific.
- A person with a `manager` role in `shelter 1` cannot perform actions in `shelter 2`, regardless of their role level.
- Attempts to perform unauthorized actions (e.g., a `manager` from `shelter 2` trying to upload an image to a pet in `shelter 1`) will result in an error.

## New Aspect - `RoleAuthAspect`
Created a new aspect to be easier to control this behavior. The idea is:
- For every endpoint we need to check for roles, the aspect check for the `token` and gets the user associated with
- It then compares to see if the person in the `token` is associated with the `shelter` that the current endpoint or operation is.

### Example 1
```
@RequiresRole(value = Role.ADMIN, shelterIdParam = 1)
@PostMapping("/add-person-to-shelter")
@Schema(description = "Add a person to a shelter")
public ResponseEntity<ShelterPersonRolesDTO> addPersonToShelter(@RequestBody AddPersonToShelterRequest request) {
        return new ResponseEntity<>(personService.addPersonToShelter(
                request.getPersonId(),
                request.getShelterId()
                ),
                HttpStatus.OK);
    }
```
The `@RequiresRole(value = Role.ADMIN, shelterIdParam = 1)` does this:
- It says that the required role for this action needs at least `ADMIN` role
- This `role` must be on the shelter that comes on the `shelterIdParam` in the position 1 ie the second argument (0,1,2)

### Example 2
```
@RequiresRole(value = Role.ADMIN, isPetOperation = true, petIdParam = 2)
public void uploadImagePet(String filePath, FileUploadDTO file, Long id) {
    if (id == null) {
        throw new IllegalArgumentException("Pet ID must be provided");
    }
...
```
The `@RequiresRole(value = Role.ADMIN, isPetOperation = true, petIdParam = 2)` does this:
- It says that the required role for this action needs at least `ADMIN` role
- Its about a pet operation
- This `role` must be on the shelter that comes on the `petIdParam` in the position 2 ie the third argument (0,1,2)

### Example 3
```
@RequiresRole(value = Role.ADMIN, shelterIdField = "shelterId")
@PostMapping("/create-pet")
@Schema(description = "Create a pet")
public ResponseEntity<PetDTO> createPet(@RequestBody PetCreateDTO petCreationDTO) {
    return new ResponseEntity<>(personService.createPet(petCreationDTO), HttpStatus.CREATED);
}
```
The `@RequiresRole(value = Role.ADMIN, shelterIdField = "shelterId")` does this:
- It says that the required role for this action needs at least `ADMIN` role
- This `role` must be on the shelter that comes on the `shelterIdField`.
- Because it comes on the body of the request, we specify the name of the field, in this case, `shelterId`

Exceptions with better output and correct HTML response status codes will be added later. 