### PR TITLE
Update Swagger config

### DIFF
--- a/src/main/java/org/mindera/fur/code/FurCodeApplication.java
+++ b/src/main/java/org/mindera/fur/code/FurCodeApplication.java
@@ -1,9 +1,12 @@
 package org.mindera.fur.code;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 
+@OpenAPIDefinition(servers = {@Server(url = "/", description = "Default Server URL")})
 @SpringBootApplication
 @EnableCaching
 public class FurCodeApplication {


### PR DESCRIPTION
- Swagger will now use base URL as default server