### PR TITLE
Shelter devenv

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,11 @@
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>me.paulschwarz</groupId>
+            <artifactId>spring-dotenv</artifactId>
+            <version>3.0.0</version>
+        </dependency>
 
     </dependencies>
     <dependencyManagement>

--- a/src/main/java/org/mindera/fur/code/controller/ShelterController.java
+++ b/src/main/java/org/mindera/fur/code/controller/ShelterController.java
@@ -99,7 +99,7 @@ public class ShelterController {
     @Operation(summary = "Delete a shelter by id", description = "Deletes a shelter with the specified id")
     @DeleteMapping("/delete/{id}")
     public ResponseEntity<Void> deleteShelter(@PathVariable @NotNull @Positive Long id) {
-        shelterService.softDeleteShelter(id);
+        shelterService.deleteShelter(id);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/src/main/java/org/mindera/fur/code/controller/pet/PetController.java
+++ b/src/main/java/org/mindera/fur/code/controller/pet/PetController.java
@@ -40,7 +40,7 @@ public class PetController {
      *
      * @return a list of all pets
      */
-    @Operation(summary = "Get all pets")
+    @Operation(summary = "Get all active pets")
     @GetMapping(value = "/all", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<PetDTO>> getAllPets() {
         List<PetDTO> petDTOs = petService.findAllPets();
@@ -53,7 +53,7 @@ public class PetController {
      * @param id The ID of the pet.
      * @return The pet.
      */
-    @Operation(summary = "Get a pet by ID")
+    @Operation(summary = "Get a active pet by ID")
     @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PetDTO> getPetById(@PathVariable @NotNull @Positive Long id) {
         PetDTO petDTO = petService.findPetById(id);
@@ -99,12 +99,12 @@ public class PetController {
     }
 
     /**
-     * Get all pet records by pet ID.
+     * Get all active pet records by pet ID.
      *
-     * @param id The ID of the pet.
-     * @return A list of pet records.
+     * @param id The ID of the active pet.
+     * @return A list of all active pet records.
      */
-    @Operation(summary = "Get all pet records by pet ID")
+    @Operation(summary = "Get all active pet records by pet ID")
     @GetMapping(value = "/{id}/record", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<PetRecordDTO>> getAllPetRecordsByPetId(@PathVariable @NotNull @Positive Long id) {
         List<PetRecordDTO> petRecordDTO = petService.getAllPetRecordsByPetId(id);
@@ -123,6 +123,56 @@ public class PetController {
     public ResponseEntity<PetRecordDTO> createPetRecord(@PathVariable @NotNull @Positive Long id, @RequestBody @Valid PetRecordCreateDTO petRecordCreateDTO) {
         PetRecordDTO petRecordDTO = petService.addPetRecord(id, petRecordCreateDTO);
         return new ResponseEntity<>(petRecordDTO, HttpStatus.CREATED);
+    }
+
+    /**
+     * Retrieves all soft-deleted pets.
+     *
+     * @return List of soft-deleted pet DTOs.
+     */
+    @Operation(summary = "Get all deleted pets")
+    @GetMapping("/deleted")
+    public ResponseEntity<List<PetDTO>> getAllDeletedPets() {
+        List<PetDTO> deletedPets = petService.findAllDeletedPets();
+        return new ResponseEntity<>(deletedPets, HttpStatus.OK);
+    }
+
+    /**
+     * Retrieves a soft-deleted pet by ID.
+     *
+     * @param id The ID of the pet.
+     * @return The soft-deleted pet DTO.
+     */
+    @Operation(summary = "Get a deleted pet by ID")
+    @GetMapping("/deleted/{id}")
+    public ResponseEntity<PetDTO> getDeletedPetById(@PathVariable @NotNull @Positive Long id) {
+        PetDTO petDTO = petService.findDeletedPetById(id);
+        return new ResponseEntity<>(petDTO, HttpStatus.OK);
+    }
+
+    /**
+     * Restores a soft-deleted pet.
+     *
+     * @param id The ID of the pet to restore.
+     */
+    @Operation(summary = "Restore a deleted pet")
+    @PostMapping("/restore/{id}")
+    public ResponseEntity<Void> restorePet(@PathVariable @NotNull @Positive Long id) {
+        petService.restorePet(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    /**
+     * Retrieves all deleted pet records for a specific pet ID.
+     *
+     * @param petId The ID of the pet.
+     * @return List of soft-deleted PetRecordDTOs.
+     */
+    @Operation(summary = "Retrieves all deleted pet records for a specific pet ID")
+    @GetMapping("/{petId}/records/deleted")
+    public ResponseEntity<List<PetRecordDTO>> getDeletedPetRecordsByPetId(@PathVariable Long petId) {
+        List<PetRecordDTO> deletedPetRecords = petService.findDeletedPetRecordEntityByPetId(petId);
+        return new ResponseEntity<>(deletedPetRecords, HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/org/mindera/fur/code/dto/pet/PetCreateDTO.java
+++ b/src/main/java/org/mindera/fur/code/dto/pet/PetCreateDTO.java
@@ -1,11 +1,15 @@
 package org.mindera.fur.code.dto.pet;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.*;
 import lombok.Data;
 import org.mindera.fur.code.model.enums.pet.PetSizeEnum;
+
+import java.time.LocalDate;
+import java.util.Date;
 
 /**
  * A DTO class for creating a pet.
@@ -29,11 +33,11 @@ public class PetCreateDTO {
     private Long shelterId;
 
     @NotNull(message = "Adopted status must be provided")
-    @Schema(description = "The adopted status of the pet", example = "true")
+    @Schema(description = "The adopted status of the pet", example = "false")
     private Boolean isAdopted;
 
     @NotNull(message = "Vaccination status is required")
-    @Schema(description = "The vaccination status of the pet", example = "true")
+    @Schema(description = "The vaccination status of the pet", example = "false")
     private Boolean isVaccinated;
 
     @NotNull(message = "Size must be provided")
@@ -53,10 +57,9 @@ public class PetCreateDTO {
     private String color;
 
     @NotNull(message = "Pet age must be provided")
-    @Min(value = 1, message = "Pet age must be greater than 1")
-    @Max(value = 99, message = "Pet age must be less than 99")
-    @Schema(description = "The age of the pet", example = "3")
-    private Integer age;
+    @PastOrPresent(message = "Pet birth date cannot be in the future")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate dateOfBirth;
 
     @NotBlank(message = "Pet observation must be provided")
     @Size(min = 1, max = 999, message = "Pet observation must be between 1 and 999 characters")

--- a/src/main/java/org/mindera/fur/code/dto/pet/PetDTO.java
+++ b/src/main/java/org/mindera/fur/code/dto/pet/PetDTO.java
@@ -9,6 +9,9 @@ import lombok.NoArgsConstructor;
 import org.mindera.fur.code.model.enums.pet.PetSizeEnum;
 
 import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.List;
 
 /**
  * A DTO class for a pet.
@@ -39,11 +42,11 @@ public class PetDTO implements Serializable {
     private Long shelterId;
 
     @NotNull(message = "Adopted status must be provided")
-    @Schema(description = "The adopted status of the pet", example = "true")
+    @Schema(description = "The adopted status of the pet", example = "false")
     private Boolean isAdopted;
 
     @NotNull(message = "Vaccination status is required")
-    @Schema(description = "The vaccination status of the pet", example = "true")
+    @Schema(description = "The vaccination status of the pet", example = "false")
     private Boolean isVaccinated;
 
     @NotNull(message = "Size must be provided")
@@ -63,13 +66,14 @@ public class PetDTO implements Serializable {
     private String color;
 
     @NotNull(message = "Pet age must be provided")
-    @Min(value = 1, message = "Pet age must be greater than 1")
-    @Max(value = 99, message = "Pet age must be less than 99")
-    @Schema(description = "The age of the pet", example = "3")
-    private Integer age;
+    @PastOrPresent(message = "Pet birth date cannot be in the future")
+    private LocalDate dateOfBirth;
 
     @NotBlank(message = "Pet observation must be provided")
     @Size(min = 1, max = 999, message = "Pet observation must be between 1 and 999 characters")
     @Schema(description = "The observations of the pet", example = "I love my pet")
     private String observations;
+
+    @Schema(description = "List of pet records associated with the pet")
+    private List<PetRecordDTO> petRecords;
 }

--- a/src/main/java/org/mindera/fur/code/dto/pet/PetRecordCreateDTO.java
+++ b/src/main/java/org/mindera/fur/code/dto/pet/PetRecordCreateDTO.java
@@ -1,12 +1,7 @@
 package org.mindera.fur.code.dto.pet;
 
-import java.time.LocalDateTime;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
@@ -20,10 +15,4 @@ public class PetRecordCreateDTO {
     @Size(max = 999, message = "Intervention cannot be longer than 999 characters")
     @Schema(description = "The intervention of the pet record", example = "Pet was sprayed")
     private String intervention;
-
-    @Valid
-    @NotNull(message = "Date is required")
-    @PastOrPresent(message = "Date cannot be in the future")
-    @Schema(description = "The date of the pet record", example = "2024-08-15T11:08:13.990Z")
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/org/mindera/fur/code/dto/pet/PetRecordDTO.java
+++ b/src/main/java/org/mindera/fur/code/dto/pet/PetRecordDTO.java
@@ -1,9 +1,9 @@
 package org.mindera.fur.code.dto.pet;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
@@ -12,6 +12,8 @@ import java.time.LocalDateTime;
  * A DTO class for a pet record.
  */
 @Data
+@NoArgsConstructor
+@Schema(description = "A pet record")
 public class PetRecordDTO implements Serializable {
 
     @Positive(message = "ID must be greater than 0")
@@ -29,7 +31,6 @@ public class PetRecordDTO implements Serializable {
     @Schema(description = "The intervention of the pet record", example = "Pet was washed")
     private String intervention;
 
-    @Valid
     @NotNull(message = "Date is required")
     @PastOrPresent(message = "Date cannot be in the future")
     @Schema(description = "The date of the pet record", example = "2024-08-15T11:08:13.990Z")

--- a/src/main/java/org/mindera/fur/code/dto/pet/PetUpdateDTO.java
+++ b/src/main/java/org/mindera/fur/code/dto/pet/PetUpdateDTO.java
@@ -1,10 +1,13 @@
 package org.mindera.fur.code.dto.pet;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 import lombok.Data;
 import org.mindera.fur.code.model.enums.pet.PetSizeEnum;
+
+import java.time.LocalDate;
 
 /**
  * A DTO class for updating a pet.
@@ -31,10 +34,11 @@ public class PetUpdateDTO {
     @Schema(description = "The color of the pet", example = "Blue")
     private String color;
 
-    @Min(value = 1, message = "Pet age must be greater than 1")
-    @Max(value = 99, message = "Pet age must be less than 99")
-    @Schema(description = "The age of the pet", example = "3")
-    private Integer age;
+    @NotNull(message = "Pet age must be provided")
+    @PastOrPresent(message = "Pet birth date cannot be in the future")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @Schema(description = "The age of the pet", example = "2023-01-01")
+    private LocalDate dateOfBirth;
 
     @Size(min = 1, max = 999, message = "Pet observation must be between 1 and 999 characters")
     @Schema(description = "The observations of the pet", example = "Healthy")

--- a/src/main/java/org/mindera/fur/code/infra/security/SecurityConfiguration.java
+++ b/src/main/java/org/mindera/fur/code/infra/security/SecurityConfiguration.java
@@ -53,10 +53,14 @@ public class SecurityConfiguration {
 
 
                         .requestMatchers(HttpMethod.POST, "/api/v1/pet").hasAnyAuthority("ADMIN")
-                        .requestMatchers(HttpMethod.PUT, "/api/v1/pet/update/{id}").hasAnyAuthority("ADMIN")
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/pet/update/{id}").hasAnyAuthority("ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/pet/delete/{id}").hasAnyAuthority("MANAGER")
                         .requestMatchers(HttpMethod.POST, "/api/v1/pet/{id}/create-record").hasAnyAuthority("ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/v1/pet/{id}/record").hasAnyAuthority("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/v1/pet/restore/{id}").hasAnyAuthority("MANAGER")
+                        .requestMatchers(HttpMethod.GET, "/api/v1/pet/{petId}/records/deleted").hasAnyAuthority("MANAGER")
+                        .requestMatchers(HttpMethod.GET, "/api/v1/pet/deleted").hasAnyAuthority("MANAGER")
+                        .requestMatchers(HttpMethod.GET, "/api/v1/pet/deleted/{id}").hasAnyAuthority("MANAGER")
 
 
                         .requestMatchers(HttpMethod.POST, "/api/v1/shelter").hasAnyAuthority("USER")

--- a/src/main/java/org/mindera/fur/code/mapper/pet/PetMapper.java
+++ b/src/main/java/org/mindera/fur/code/mapper/pet/PetMapper.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * A mapper class for mapping pets.
  */
-@Mapper
+@Mapper(uses = PetRecordMapper.class)
 public interface PetMapper {
 
     PetMapper INSTANCE = Mappers.getMapper(PetMapper.class);
@@ -21,11 +21,15 @@ public interface PetMapper {
     @Mapping(source = "shelter.id", target = "shelterId")
     PetDTO toDTO(Pet pet);
 
+    @Mapping(source = "petTypeId", target = "petType.id")
+    @Mapping(source = "shelterId", target = "shelter.id")
     Pet toModel(PetDTO dto);
 
     @Mapping(source = "petTypeId", target = "petType.id")
     @Mapping(source = "shelterId", target = "shelter.id")
     Pet toModel(PetCreateDTO dto);
 
+    @Mapping(source = "petType.id", target = "petTypeId")
+    @Mapping(source = "shelter.id", target = "shelterId")
     List<PetDTO> toDto(List<Pet> pet);
 }

--- a/src/main/java/org/mindera/fur/code/mapper/pet/PetRecordMapper.java
+++ b/src/main/java/org/mindera/fur/code/mapper/pet/PetRecordMapper.java
@@ -18,6 +18,7 @@ public interface PetRecordMapper {
     @Mapping(source = "pet.id", target = "petId")
     PetRecordDTO toDTO(PetRecord petRecord);
 
+    @Mapping(source = "petId", target = "pet.id")
     PetRecord toModel(PetRecordDTO petRecordDTO);
 
     PetRecord toModel(PetRecordCreateDTO petRecordCreateDTO);

--- a/src/main/java/org/mindera/fur/code/messages/pet/PetMessages.java
+++ b/src/main/java/org/mindera/fur/code/messages/pet/PetMessages.java
@@ -7,4 +7,6 @@ public record PetMessages() {
     public static final String PET_NOT_FOUND = "Pet not found with ID: ";
     public static final String PET_TYPE_NOT_FOUND = "Pet type not found with ID: ";
     public static final String SHELTER_NOT_FOUND = "Shelter not found with ID: ";
+    public static final String PET_RECORD_NOT_FOUND = "Pet record not found with ID: ";
+    public static final String DELETED_PET_NOT_FOUND = "Deleted pet not found with ID: ";
 }

--- a/src/main/java/org/mindera/fur/code/model/Shelter.java
+++ b/src/main/java/org/mindera/fur/code/model/Shelter.java
@@ -6,11 +6,9 @@ import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.mindera.fur.code.model.interfaces.SoftDeletable;
 import org.mindera.fur.code.model.pet.Pet;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Set;
 
 /**
@@ -21,7 +19,7 @@ import java.util.Set;
 @Entity
 @NoArgsConstructor
 @Table(name = "shelter")
-public class Shelter implements SoftDeletable {
+public class Shelter {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -80,38 +78,41 @@ public class Shelter implements SoftDeletable {
     @Column(nullable = false)
     private LocalDate creationDate;
 
+    @Column
+    private String description;
+
+    @Column
+    private String facebookUrl;
+
+    @Column
+    private String instagramUrl;
+
+    @Column
+    private String webPageUrl;
+
     /**
      * The set of ShelterPersonRoles.
      */
-    @OneToMany(mappedBy = "shelter", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "shelter", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @Schema(description = "The collection of person roles associated with the shelter")
     private Set<ShelterPersonRoles> shelterPersonRoles;
 
     /**
      * The set of Pet.
      */
-    @OneToMany(mappedBy = "shelter", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "shelter", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @Schema(description = "The collection of pets associated with the shelter")
     private Set<Pet> pet;
 
     /**
      * The set of Donation.
      */
-    @OneToMany(mappedBy = "shelter")
+    @OneToMany(mappedBy = "shelter", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @Schema(description = "The collection of donations associated with the shelter")
     private Set<Donation> donations;
 
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
-    // SoftDeletable methods
-    @Override
-    public LocalDateTime getDeletedAt() {
-        return deletedAt;
-    }
-
-    @Override
-    public void setDeletedAt(LocalDateTime deletedAt) {
-        this.deletedAt = deletedAt;
-    }
+    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "person_id")
+    @Schema(description = "The person who donated")
+    private Person person;
 }

--- a/src/main/java/org/mindera/fur/code/model/pet/Pet.java
+++ b/src/main/java/org/mindera/fur/code/model/pet/Pet.java
@@ -2,19 +2,22 @@ package org.mindera.fur.code.model.pet;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.mindera.fur.code.model.Shelter;
 import org.mindera.fur.code.model.enums.pet.PetSizeEnum;
 import org.mindera.fur.code.model.interfaces.SoftDeletable;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 /**
  * A model class for a pet.
  */
-@Data
+@Getter
+@Setter
 @Entity
 @NoArgsConstructor
 @Table(name = "pet")
@@ -64,10 +67,9 @@ public class Pet implements SoftDeletable {
     private String color;
 
     @NotNull(message = "Pet age must be provided")
-    @Min(value = 1, message = "Pet age must be greater than 1")
-    @Max(value = 99, message = "Pet age must be less than 99")
+    @PastOrPresent(message = "Pet birth date cannot be in the future")
     @Column(nullable = false)
-    private Integer age;
+    private LocalDate dateOfBirth;
 
     @NotBlank(message = "Pet observation must be provided")
     @Size(min = 1, max = 999, message = "Pet observation must be between 1 and 999 characters")

--- a/src/main/java/org/mindera/fur/code/model/pet/PetRecord.java
+++ b/src/main/java/org/mindera/fur/code/model/pet/PetRecord.java
@@ -1,26 +1,28 @@
 package org.mindera.fur.code.model.pet;
 
 import jakarta.persistence.*;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import org.mindera.fur.code.model.interfaces.SoftDeletable;
 
 import java.time.LocalDateTime;
 
 /**
  * A model class for a pet record.
  */
-@Data
+@Getter
+@Setter
 @Entity
 @Table(name = "pet_record")
-public class PetRecord {
+public class PetRecord implements SoftDeletable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull(message = "Pet is required")
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pet_id", nullable = false)
     private Pet pet;
 
@@ -29,9 +31,22 @@ public class PetRecord {
     @Column(length = 999)
     private String intervention;
 
-    @Valid
     @NotNull(message = "Date is required")
     @PastOrPresent(message = "Date cannot be in the future")
     @Column(nullable = false)
     private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    // SoftDeletable methods
+    @Override
+    public LocalDateTime getDeletedAt() {
+        return deletedAt;
+    }
+
+    @Override
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
 }

--- a/src/main/java/org/mindera/fur/code/repository/ShelterRepository.java
+++ b/src/main/java/org/mindera/fur/code/repository/ShelterRepository.java
@@ -1,36 +1,15 @@
 package org.mindera.fur.code.repository;
 
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.mindera.fur.code.model.Shelter;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Spring Data JPA repository for the Shelter entity.
  */
 @Schema(description = "The shelter repository")
 @Repository
-public interface ShelterRepository extends SoftDeleteRepository<Shelter, Long> {
-
-    /**
-     * Retrieves all shelters, including soft-deleted ones.
-     *
-     * @return List of all shelters.
-     */
-    @Query("SELECT s FROM Shelter s")
-    List<Shelter> findAllIncludingDeleted();
-
-    /**
-     * Retrieves a shelter by ID, including soft-deleted ones.
-     *
-     * @param id The ID of the shelter.
-     * @return Optional containing the shelter if found.
-     */
-    @Query("SELECT s FROM Shelter s WHERE s.id = :id")
-    Optional<Shelter> findByIdIncludingDeleted(@Param("id") Long id);
+public interface ShelterRepository extends JpaRepository<Shelter, Long> {
 }

--- a/src/main/java/org/mindera/fur/code/repository/SoftDeleteRepository.java
+++ b/src/main/java/org/mindera/fur/code/repository/SoftDeleteRepository.java
@@ -3,7 +3,9 @@ package org.mindera.fur.code.repository;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.mindera.fur.code.model.interfaces.SoftDeletable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,7 +33,47 @@ public interface SoftDeleteRepository<T extends SoftDeletable, ID> extends JpaRe
         return findByIdAndDeletedAtIsNull(id);
     }
 
+    /**
+     * Retrieves all soft-deleted entities.
+     *
+     * @return List of soft-deleted entities.
+     */
+    default List<T> findAllDeleted() {
+        return findAllByDeletedAtIsNotNull();
+    }
+
+    /**
+     * Retrieves a soft-deleted entity by its ID.
+     *
+     * @param id The ID of the entity.
+     * @return An Optional containing the entity if found and deleted.
+     */
+    default Optional<T> findDeletedById(ID id) {
+        return findByIdAndDeletedAtIsNotNull(id);
+    }
+
+    /**
+     * Retrieves an entity by its ID, including soft-deleted ones.
+     *
+     * @param id The ID of the entity.
+     * @return An Optional containing the entity if found.
+     */
+    @Query("SELECT e FROM #{#entityName} e WHERE e.id = :id")
+    Optional<T> findByIdIncludingDeleted(@Param("id") ID id);
+
+    /**
+     * Retrieves all entities, including soft-deleted ones.
+     *
+     * @return List of all entities.
+     */
+    @Query("SELECT e FROM #{#entityName} e")
+    List<T> findAllIncludingDeleted();
+
     List<T> findAllByDeletedAtIsNull();
 
     Optional<T> findByIdAndDeletedAtIsNull(ID id);
+
+    List<T> findAllByDeletedAtIsNotNull();
+
+    Optional<T> findByIdAndDeletedAtIsNotNull(ID id);
 }

--- a/src/main/java/org/mindera/fur/code/repository/pet/PetRecordRepository.java
+++ b/src/main/java/org/mindera/fur/code/repository/pet/PetRecordRepository.java
@@ -2,13 +2,23 @@ package org.mindera.fur.code.repository.pet;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.mindera.fur.code.model.pet.PetRecord;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.mindera.fur.code.repository.SoftDeleteRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 /**
  * Pet record repository.
  */
 @Schema(description = "Pet record repository")
 @Repository
-public interface PetRecordRepository extends JpaRepository<PetRecord, Long> {
+public interface PetRecordRepository extends SoftDeleteRepository<PetRecord, Long> {
+
+    /**
+     * Retrieves all soft-deleted pet records associated with a specific pet ID.
+     *
+     * @param petId The ID of the pet.
+     * @return List of soft-deleted PetRecords.
+     */
+    List<PetRecord> findAllByPet_IdAndDeletedAtIsNotNull(Long petId);
 }

--- a/src/main/java/org/mindera/fur/code/repository/pet/PetRepository.java
+++ b/src/main/java/org/mindera/fur/code/repository/pet/PetRepository.java
@@ -3,12 +3,7 @@ package org.mindera.fur.code.repository.pet;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.mindera.fur.code.model.pet.Pet;
 import org.mindera.fur.code.repository.SoftDeleteRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Pet repository.
@@ -16,21 +11,4 @@ import java.util.Optional;
 @Schema(description = "Pet repository")
 @Repository
 public interface PetRepository extends SoftDeleteRepository<Pet, Long> {
-
-    /**
-     * Retrieves all pets, including soft-deleted ones.
-     *
-     * @return List of all pets.
-     */
-    @Query("SELECT p FROM Pet p")
-    List<Pet> findAllIncludingDeleted();
-
-    /**
-     * Retrieves a pet by ID, including soft-deleted ones.
-     *
-     * @param id The ID of the pet.
-     * @return Optional containing the pet if found.
-     */
-    @Query("SELECT p FROM Pet p WHERE p.id = :id")
-    Optional<Pet> findByIdIncludingDeleted(@Param("id") Long id);
 }

--- a/src/main/java/org/mindera/fur/code/service/AdoptionRequestService.java
+++ b/src/main/java/org/mindera/fur/code/service/AdoptionRequestService.java
@@ -238,7 +238,7 @@ public class AdoptionRequestService {
     }
 
     private Shelter findAndAssignShelter(Long id) {
-        return shelterService.findActiveShelterEntityById(id);
+        return shelterService.findShelterEntityById(id);
     }
 
     private Person findAndAssignPerson(Long id) {

--- a/src/main/java/org/mindera/fur/code/service/PersonService.java
+++ b/src/main/java/org/mindera/fur/code/service/PersonService.java
@@ -259,7 +259,7 @@ public class PersonService {
         Person person = personRepository.findById(personId).orElseThrow(
                 () -> new PersonException(PersonMessages.PERSON_NOT_FOUND)
         );
-        Shelter shelter = shelterRepository.findActiveById(shelterId).orElseThrow(
+        Shelter shelter = shelterRepository.findById(shelterId).orElseThrow(
                 () -> new PersonException(PersonMessages.SHELTER_NOT_FOUND)
         );
 

--- a/src/main/java/org/mindera/fur/code/service/ShelterService.java
+++ b/src/main/java/org/mindera/fur/code/service/ShelterService.java
@@ -24,7 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -72,7 +71,7 @@ public class ShelterService {
      */
 //    @Cacheable(cacheNames = "shelters")
     public List<ShelterDTO> getAllShelters() {
-        List<Shelter> shelters = shelterRepository.findAllActive();
+        List<Shelter> shelters = shelterRepository.findAll();
         return shelters.stream().map(ShelterMapper.INSTANCE::toDTO).toList();
     }
 
@@ -84,7 +83,7 @@ public class ShelterService {
      */
 //    @Cacheable(cacheNames = "shelter", key = "#id")
     public ShelterDTO getShelterById(@NotNull @Positive Long id) {
-        Shelter shelter = findActiveShelterEntityById(id);
+        Shelter shelter = findShelterEntityById(id);
         return ShelterMapper.INSTANCE.toDTO(shelter);
     }
 
@@ -114,7 +113,7 @@ public class ShelterService {
 //    @CacheEvict(cacheNames = "shelters", allEntries = true)
     @Transactional
     public ShelterDTO updateShelter(@NotNull @Positive Long id, @Valid ShelterUpdateDTO shelterUpdateDTO) {
-        Shelter shelter = findActiveShelterEntityById(id);
+        Shelter shelter = findShelterEntityById(id);
 
         ShelterUpdateMapper.INSTANCE.updateShelterFromDto(shelterUpdateDTO, shelter);
 
@@ -133,10 +132,9 @@ public class ShelterService {
 //            @CacheEvict(cacheNames = "shelters", allEntries = true)
 //    })
     @Transactional
-    public void softDeleteShelter(@NotNull @Positive Long id) {
-        Shelter shelter = findActiveShelterEntityById(id);
-        shelter.setDeletedAt(LocalDateTime.now());
-        shelterRepository.save(shelter);
+    public void deleteShelter(@NotNull @Positive Long id) {
+        Shelter shelter = findShelterEntityById(id);
+        shelterRepository.delete(shelter);
     }
 
     /**
@@ -149,7 +147,7 @@ public class ShelterService {
      */
     public void addPetToShelter(@NotNull @Positive Long shelterId, @NotNull @Positive Long petId) {
         Pet pet = petService.findActivePetEntityById(petId);
-        Shelter shelter = findActiveShelterEntityById(shelterId);
+        Shelter shelter = findShelterEntityById(shelterId);
 
         pet.setShelter(shelter);
         petRepository.save(pet);
@@ -186,8 +184,8 @@ public class ShelterService {
      * @return The Shelter entity.
      * @throws EntityNotFoundException if the shelter with the specified ID is not found.
      */
-    public Shelter findActiveShelterEntityById(@NotNull @Positive Long id) {
-        return shelterRepository.findActiveById(id)
+    public Shelter findShelterEntityById(@NotNull @Positive Long id) {
+        return shelterRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(ShelterMessages.SHELTER_NOT_FOUND + id));
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,11 @@
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.application.name=fur-code
-spring.datasource.url=jdbc:postgresql://postgres:5432/furcode
-spring.datasource.username=postgres
-spring.datasource.password=password
+#spring.datasource.url=jdbc:postgresql://postgres:5432/furcode
+
+spring.datasource.url=jdbc:postgresql://${DATABASE_HOST}
+spring.datasource.username=${DATABASE_USERNAME}
+spring.datasource.password=${DATABASE_PASSWORD}
+
 spring.jpa.hibernate.ddl-auto=update
 minio.endpoint=http://minio:9000
 minio.accessKey=changeme


### PR DESCRIPTION
Remove/clean soft-delete on Shelter, need to be implemented to delete the associated entities after setting the deletedAt.

Implemented soft-delete on pet and pet record.
Now, when a pet is deleted, the pet record is deleted also.

The Pet controller now have endpoints to retrieve and restore soft-deleted pets, only managers can perform this actions.

Now the PetDTO return a list of pet records too.
